### PR TITLE
Add: Carousel5 레이아웃 및 기능 구현

### DIFF
--- a/src/components/Carousel5/Carousel5.js
+++ b/src/components/Carousel5/Carousel5.js
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from 'react';
+import styles from './Carousel5.module.scss';
+import MovieCard from './MovieCard/MovieCard';
+const Carousel5 = props => {
+  const SliderWrapperRef = React.useRef();
+  const [leftButtonOn, setLeftButtonOn] = useState('Hidden');
+  const [rightButtonOn, setRightButtonOn] = useState('');
+  function MoveRight() {
+    SliderWrapperRef.current.scrollTo(
+      SliderWrapperRef.current.scrollLeft +
+        SliderWrapperRef.current.clientWidth,
+      0
+    );
+  }
+  function MoveLeft() {
+    SliderWrapperRef.current.scrollTo(
+      SliderWrapperRef.current.scrollLeft -
+        SliderWrapperRef.current.clientWidth,
+      0
+    );
+  }
+  function checkScrollPos() {
+    if (SliderWrapperRef.current.scrollLeft <= 0) {
+      setLeftButtonOn('Hidden');
+      return;
+    } else if (
+      SliderWrapperRef.current.scrollLeft >=
+      SliderWrapperRef.current.scrollWidth -
+        SliderWrapperRef.current.clientWidth
+    ) {
+      setRightButtonOn('Hidden');
+      return;
+    }
+    setRightButtonOn('');
+    setLeftButtonOn('');
+  }
+  return (
+    <div className={styles.Carousel5Wrapper}>
+      <div className={styles.DivForButton}>
+        <button
+          className={`${styles.Button} ${styles[leftButtonOn]}`}
+          onClick={MoveLeft}
+        >
+          <img
+            width="-100%"
+            src="/image/arrow.svg"
+            style={{
+              WebkitTransform: 'scaleX(-1)',
+              transform: 'scaleX(-1)',
+            }}
+          />
+        </button>
+        <button
+          className={`${styles.Button} ${styles[rightButtonOn]}`}
+          onClick={MoveRight}
+        >
+          <img src="/image/arrow.svg" />
+        </button>
+      </div>
+      <div className={styles.Title}>위챠 Top 10 영화</div>
+      <div
+        className={styles.SliderWrapper}
+        ref={SliderWrapperRef}
+        onScroll={checkScrollPos}
+      >
+        {/*레이아웃 완료. 여기 맵만 해주면 끝남.*/}
+        <MovieCard
+          title="서울의 연인들"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="1"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/28.png"
+        />
+        <MovieCard
+          title="탐정교실"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="2"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/22.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="3"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/24.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="4"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/12.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="5"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/34.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="6"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/40.png"
+        />
+        <MovieCard
+          title="서울의 연인들"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="7"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/23.png"
+        />
+        <MovieCard
+          title="탐정교실"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="8"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/50.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="9"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/4.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="10"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/25.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="11"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/22.png"
+        />
+        <MovieCard
+          title="맨 인 더 룸 3"
+          releasedYear="2022"
+          countryName="한국"
+          averageRatingScore="3.5"
+          sequenceNumber="12"
+          imgUrl="https://raw.githubusercontent.com/nsoarim/wetchaimage/main/poster/45.png"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Carousel5;

--- a/src/components/Carousel5/Carousel5.module.scss
+++ b/src/components/Carousel5/Carousel5.module.scss
@@ -1,0 +1,67 @@
+.Carousel5Wrapper {
+  position: relative;
+  margin-top: 60px;
+  padding-left: 10px;
+  padding-right: 10px;
+  @media screen and (max-width: 900px) {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+.SliderWrapper {
+  white-space: nowrap;
+  position: relative;
+  width: 100%;
+  overflow-y: hidden;
+  overflow-x: auto;
+  scrollbar-width: none;
+  scroll-behavior: smooth;
+  @media screen and (max-width: 900px) {
+    padding-left: 10px;
+  }
+}
+.SliderWrapper::-webkit-scrollbar {
+  display: none;
+}
+.Title {
+  font-size: 23px;
+  font-weight: bold;
+  padding-bottom: 10px;
+  padding-top: 25px;
+  padding-left: 10px;
+}
+
+.DivForButton {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0%);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 300;
+  outline: none;
+  pointer-events: none;
+}
+
+.Button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  border: 0px;
+  pointer-events: all;
+  background-color: white;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
+
+  @media screen and (max-width: 900px) {
+    visibility: hidden;
+  }
+}
+
+.Hidden {
+  visibility: hidden;
+}

--- a/src/components/Carousel5/MovieCard/MovieCard.js
+++ b/src/components/Carousel5/MovieCard/MovieCard.js
@@ -1,0 +1,26 @@
+import styles from './MovieCard.module.scss';
+
+const MovieCard = props => {
+  return (
+    <div
+      //style={{ width: props.MovieCardWrapperWidth }}
+      className={styles.MovieCardWrapper}
+    >
+      <div className={styles.PosterBox}>
+        <div className={styles.SequenceNumberBox}>{props.sequenceNumber}</div>
+        <img className={styles.PosterImage} src={props.imgUrl} />
+      </div>
+      <div className={styles.MovieInfoWrapper}>
+        <div className={styles.MovieInfoTitle}>{props.title}</div>
+        <div className={styles.MovieInfoSubWrapper}>
+          <div>{props.releasedYear + '·' + props.countryName}</div>
+          <div className={styles.MovieInfoRating}>
+            평균 ★ {props.averageRatingScore}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MovieCard;

--- a/src/components/Carousel5/MovieCard/MovieCard.module.scss
+++ b/src/components/Carousel5/MovieCard/MovieCard.module.scss
@@ -1,0 +1,65 @@
+* {
+  box-sizing: border-box;
+}
+.MovieCardWrapper {
+  display: inline-block;
+  padding: 8px;
+  width: 20%;
+  @media screen and (max-width: 1200px) {
+    width: 25%;
+  }
+  @media screen and (max-width: 900px) {
+    width: 32%;
+  }
+}
+
+.PosterBox {
+  position: relative;
+  left: 0;
+  top: 0;
+  width: 100%;
+  border-radius: 5px;
+  overflow: hidden;
+  border: solid rgb(230, 230, 230) 1px;
+}
+.PosterImage {
+  display: block;
+  width: 100%;
+}
+.MovieInfoWrapper {
+  width: 100%;
+  padding-top: 5px;
+  > div {
+    padding: 5px 0 5px 0;
+  }
+}
+.MovieInfoTitle {
+  font-size: 18px;
+  font-weight: bold;
+}
+.MovieInfoSubWrapper {
+  font-size: 15px;
+}
+.MovieInfoRating {
+  font-size: 15px;
+  padding-top: 3px;
+  color: rgb(67, 68, 82);
+}
+
+.SequenceNumberBox {
+  position: absolute;
+  border-radius: 5px;
+  font-size: 18px;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  vertical-align: middle;
+  left: 10px;
+  top: 10px;
+  padding-top: 4px;
+  width: 27px;
+  height: 27px;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: white;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- Carousel5컴포넌트 레이아웃 구성 및 기능 구현

<br />

## :: 구현 사항 설명
1. MovieCard 컴포넌트 구현
- Carousel5의 가로슬라이더 영역에 표시될 컴포넌트들인 MovieCard 컴포넌트 구현
- Media Query를 사용하여 디스플레이 크기에 따라 스타일이 변경됨
- props로 title, releasedYear, countryName, averageRatingScore, sequenceNumber, imgUrl를 받음

2. Carousel5 컴포넌트 레이아웃 구성
- 가로 스크롤 가능한 Carousel slider인 Carousel5 컴포넌트의 레이아웃 구성

3. Carousel5 컴포넌트 가로 슬라이드 버튼 기능 구현
- 컴포넌트 양쪽의 버튼을 클릭시 현재 표시된 슬라이드 영역의 크기만큼 왼쪽 혹은 오른쪽으로 스크롤이 이동하는 기능 구현
- 스크롤바가 0이나 스크롤 영역의 최대치에 위치시 왼쪽 혹은 오른쪽 방향 버튼을 숨기는 기능 구현

<br />

## :: 성장 포인트
- 스크롤 영역에 대한 다양한 상식들을 학습하였다.
- ref를 사용하여 컴포넌트의 DOM에 접근하여 정보를 받아오거나 적용할 수 있다.
<br />

## :: 기타 질문 및 특이 사항
- 없음
