### PR TITLE
Add: Comment 컴포넌트 레이아웃 및 초기 기능구현

### DIFF
--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -1,0 +1,93 @@
+import React, { useState, useEffect } from 'react';
+import styles from './Comment.module.scss';
+import CommentCard from './CommentCard/CommentCard';
+
+const Comment = props => {
+  const SliderWrapperRef = React.useRef();
+  const [leftButtonOn, setLeftButtonOn] = useState('Hidden');
+  const [rightButtonOn, setRightButtonOn] = useState('');
+  function MoveRight() {
+    SliderWrapperRef.current.scrollTo(
+      SliderWrapperRef.current.scrollLeft +
+        SliderWrapperRef.current.clientWidth,
+      0
+    );
+  }
+  function MoveLeft() {
+    SliderWrapperRef.current.scrollTo(
+      SliderWrapperRef.current.scrollLeft -
+        SliderWrapperRef.current.clientWidth,
+      0
+    );
+  }
+  function checkScrollPos() {
+    if (SliderWrapperRef.current.scrollLeft == 0) {
+      setLeftButtonOn('Hidden');
+      return;
+    } else if (
+      SliderWrapperRef.current.scrollLeft >=
+      SliderWrapperRef.current.scrollWidth -
+        SliderWrapperRef.current.clientWidth
+    ) {
+      setRightButtonOn('Hidden');
+      return;
+    }
+    setRightButtonOn('');
+    setLeftButtonOn('');
+  }
+  return (
+    <div className={styles.Carousel5Wrapper}>
+      <div className={styles.DivForButton}>
+        <button
+          className={`${styles.Button} ${styles[leftButtonOn]}`}
+          onClick={MoveLeft}
+        >
+          <img
+            width="-100%"
+            src="/image/arrow.svg"
+            style={{
+              WebkitTransform: 'scaleX(-1)',
+              transform: 'scaleX(-1)',
+            }}
+          />
+        </button>
+        <button
+          className={`${styles.Button} ${styles[rightButtonOn]}`}
+          onClick={MoveRight}
+        >
+          <img src="/image/arrow.svg" />
+        </button>
+      </div>
+      <div className={styles.Title}>코멘트</div>
+      <div
+        className={styles.SliderWrapper}
+        ref={SliderWrapperRef}
+        onScroll={checkScrollPos}
+      >
+        {/*레이아웃 완료 여기 맵만 해주면 끝남*/}
+        <CommentCard
+          userName="김아무개"
+          likeCount="3"
+          commentContent="세계를 향한 대화, 유니코드로 하십시오. 제10회 유니코드 국제 회의가 1997년 3월 10일부터 12일까지 독일의 마인즈에서 열립니다. 지금 등록하십시오. 이 회의에서는 업계 전반의 전문가들이 함께 모여 다음과 같은 분야를 다룹니다. - 인터넷과 유니코드, 국제화와 지역화, 운영 체제와 응용 프로그램에서 유니코드의 구현, 글꼴, 문자 배열, 다국어 컴퓨팅."
+        />
+        <CommentCard
+          userName="김아무개"
+          likeCount="3"
+          commentContent="세계를 향한 대화, 유니코드로 하십시오. 제10회 유니코드 국제 회의가 1997년 3월 10일부터 12일까지 독일의 마인즈에서 열립니다. 지금 등록하십시오. 이 회의에서는 업계 전반의 전문가들이 함께 모여 다음과 같은 분야를 다룹니다. - 인터넷과 유니코드, 국제화와 지역화, 운영 체제와 응용 프로그램에서 유니코드의 구현, 글꼴, 문자 배열, 다국어 컴퓨팅."
+        />
+        <CommentCard
+          userName="김아무개"
+          likeCount="3"
+          commentContent="세계를 향한 대화, 유니코드로 하십시오. 제10회 유니코드 국제 회의가 1997년 3월 10일부터 12일까지 독일의 마인즈에서 열립니다. 지금 등록하십시오. 이 회의에서는 업계 전반의 전문가들이 함께 모여 다음과 같은 분야를 다룹니다. - 인터넷과 유니코드, 국제화와 지역화, 운영 체제와 응용 프로그램에서 유니코드의 구현, 글꼴, 문자 배열, 다국어 컴퓨팅."
+        />
+        <CommentCard
+          userName="김아무개"
+          likeCount="3"
+          commentContent="세계를 향한 대화, 유니코드로 하십시오. 제10회 유니코드 국제 회의가 1997년 3월 10일부터 12일까지 독일의 마인즈에서 열립니다. 지금 등록하십시오. 이 회의에서는 업계 전반의 전문가들이 함께 모여 다음과 같은 분야를 다룹니다. - 인터넷과 유니코드, 국제화와 지역화, 운영 체제와 응용 프로그램에서 유니코드의 구현, 글꼴, 문자 배열, 다국어 컴퓨팅."
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Comment;

--- a/src/components/Comment/Comment.module.scss
+++ b/src/components/Comment/Comment.module.scss
@@ -1,0 +1,66 @@
+.Carousel5Wrapper {
+  position: relative;
+  margin-top: 60px;
+  @media screen and (max-width: 900px) {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+.SliderWrapper {
+  white-space: nowrap;
+  position: relative;
+  width: 100%;
+  overflow-y: hidden;
+  overflow-x: auto;
+  scrollbar-width: none;
+  scroll-behavior: smooth;
+  @media screen and (max-width: 900px) {
+    padding-left: 10px;
+  }
+}
+.SliderWrapper::-webkit-scrollbar {
+  display: none;
+}
+.Title {
+  font-size: 21px;
+  font-weight: bold;
+  padding-bottom: 10px;
+  padding-top: 25px;
+  padding-left: 17px;
+}
+
+.DivForButton {
+  padding: 10px;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0%);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 300;
+  outline: none;
+  pointer-events: none;
+}
+
+.Button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  border: 0px;
+  pointer-events: all;
+  background-color: white;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
+
+  @media screen and (max-width: 900px) {
+    visibility: hidden;
+  }
+}
+
+.Hidden {
+  visibility: hidden;
+}

--- a/src/components/Comment/CommentCard/CommentCard.js
+++ b/src/components/Comment/CommentCard/CommentCard.js
@@ -1,0 +1,39 @@
+import styles from './CommentCard.module.scss';
+
+const CommentCard = props => {
+  let shortCommentContent = '';
+
+  function cutCommentContent(inputText) {
+    if (inputText.length > 200) {
+      for (let i = 0; i < 200; i++) {
+        shortCommentContent += inputText[i];
+      }
+      shortCommentContent += '...';
+    } else {
+      shortCommentContent = inputText;
+    }
+  }
+
+  cutCommentContent(props.commentContent);
+
+  return (
+    <div className={styles.CommentCardWrapper}>
+      <div className={styles.NameAndWantsWrapper}>
+        <div className={styles.Name}>{props.userName}</div>
+        <button className={styles.Want}>보고싶어요</button>
+      </div>
+      <div className={styles.Line} />
+      <div className={styles.CommentContentWrapper}>{shortCommentContent}</div>
+      <div className={styles.Line} />
+      <div className={styles.CommentLikeWrapper}>
+        <div className={styles.LikeCount}>{props.likeCount}</div>
+      </div>
+      <div className={styles.Line} />
+      <div className={styles.CommentLikeWrapper}>
+        <div className={styles.LikeButton}>좋아요</div>
+      </div>
+    </div>
+  );
+};
+
+export default CommentCard;

--- a/src/components/Comment/CommentCard/CommentCard.module.scss
+++ b/src/components/Comment/CommentCard/CommentCard.module.scss
@@ -1,0 +1,71 @@
+* {
+  box-sizing: border-box;
+}
+.CommentCardWrapper {
+  display: inline-block;
+  padding: 0 15px 0 15px;
+  width: 45%;
+  background-color: rgb(239, 239, 239);
+  border-radius: 5px;
+  margin: 6px;
+
+  @media screen and (max-width: 900px) {
+    width: 90%;
+  }
+}
+.Name {
+  font-size: 18px;
+}
+
+.NameAndWantsWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 16px 0 15px;
+}
+
+.CommentContentWrapper {
+  width: 100%;
+  height: 120px;
+  margin: 20px 0 20px;
+  font-size: 17px;
+  overflow: hidden;
+  white-space: normal;
+  word-break: keep-all;
+}
+
+.CommentLikeWrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  margin: 15px 0 15px;
+}
+.LikeButton {
+  color: rgb(252, 14, 91);
+  font-size: 18px;
+}
+
+.Want {
+  text-align: center;
+  padding: 6px 11px 6px 11px;
+  background-color: white;
+  border: solid rgb(230, 230, 230) 1px;
+  border-radius: 50px;
+}
+
+.Rating {
+}
+
+.LikeCount {
+  color: rgb(101, 101, 101);
+  font-size: 13px;
+  margin-top: 0.3em;
+}
+
+.Line {
+  width: 100%;
+  height: 1px;
+  background-color: rgb(220, 220, 220);
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 디테일페이지의 Comment컴포넌트 레이아웃 구성 및 기능 구현

<br />

## :: 구현 사항 설명
1. CommentCard 컴포넌트 구현
- Comment의 가로슬라이더 영역에 표시될 컴포넌트들인 CommentCard 컴포넌트 구현
- Media Query를 사용하여 디스플레이 크기에 따라 스타일이 변경됨

2.코멘트의 내용이 너무 길시 200글자에서 자르고 "..."을 붙혀서 표시하도록 구현

3. Comment 컴포넌트 레이아웃 구성
- 가로 스크롤 가능한 Carousel slider인 Comment 컴포넌트의 레이아웃 구성

4. Comment 컴포넌트 가로 슬라이드 버튼 기능 구현
- 컴포넌트 양쪽의 버튼을 클릭시 현재 표시된 슬라이드 영역의 크기만큼 왼쪽 혹은 오른쪽으로 스크롤이 이동하는 기능 구현
- 스크롤바가 0이나 스크롤 영역의 최대치에 위치시 왼쪽 혹은 오른쪽 방향 버튼을 숨기는 기능 구현

<br />

## :: 성장 포인트
- 스크롤 영역에 대한 다양한 상식들을 학습하였다.
- ref를 사용하여 컴포넌트의 DOM에 접근하여 정보를 받아오거나 적용할 수 있다.
<br />

## :: 기타 질문 및 특이 사항
- 없음
