### PR TITLE
ADD: Carousel6 기능 구현 (목데이터 이용 중)

### DIFF
--- a/src/components/Carousel6/Carousel6.js
+++ b/src/components/Carousel6/Carousel6.js
@@ -1,0 +1,124 @@
+import styles from './Carousel6.module.scss';
+import { useState, useRef, useEffect } from 'react';
+import Carousel6Card from './Carousel6Card';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCircleChevronRight,
+  faCircleChevronLeft,
+} from '@fortawesome/free-solid-svg-icons';
+
+function Carousel6() {
+  const [moviePosters, setMoviePosters] = useState({
+    movies: [],
+  });
+
+  const [scrollXTop, setScrollXTop] = useState(0);
+  const [scrollXBottom, setScrollXTBottom] = useState(0);
+  const sectionTop = useRef(null);
+  const sectionBottom = useRef(null);
+
+  const cursorTop = event => {
+    setScrollXTop(event.target.scrollLeft);
+    console.log('scrollXtop ', scrollXTop);
+    console.log('scrollWidth ', event.target.scrollWidth);
+    console.log('clientWidth ', event.target.clientWidth);
+    console.log(
+      'scrollWidth - clientWidth ',
+      event.target.scrollWidth - event.target.clientWidth
+    );
+  };
+
+  const cursorBottom = event => {
+    setScrollXTBottom(event.target.scrollLeft);
+  };
+  // const cursorBottom = event => {
+  //   setScrollX(event.target.scrollLeft);
+  // };
+
+  const moveLeftTop = scrollOffset => {
+    sectionTop.current.scrollLeft += scrollOffset;
+  };
+
+  const moveLeftBottom = scrollOffset => {
+    sectionBottom.current.scrollLeft += scrollOffset;
+  };
+
+  useEffect(() => {
+    fetch('/data/moviesChae.json')
+      .then(res => res.json())
+      .then(data => {
+        setMoviePosters(data);
+      });
+  }, []);
+
+  return (
+    <div className={styles.wholeWrapper}>
+      <div className={styles.wrapper}>
+        <div className={styles.carouselComp}>
+          <title className={styles.CategoryTitle}>평균별점이 높은 작품</title>
+          <section
+            className={styles.topSlider}
+            onScroll={cursorTop}
+            ref={sectionTop}
+          >
+            {moviePosters.movies.map(movies => (
+              <Carousel6Card key={movies.id} movies={movies} />
+            ))}
+            {scrollXTop === 0 ? null : (
+              <FontAwesomeIcon
+                icon={faCircleChevronLeft}
+                className={styles.topLeft}
+                onClick={() => {
+                  moveLeftTop(-1434);
+                }}
+              />
+            )}
+            {scrollXTop > 1400 ? null : (
+              <FontAwesomeIcon
+                icon={faCircleChevronRight}
+                className={styles.topRight}
+                onClick={() => {
+                  moveLeftTop(1434);
+                }}
+              />
+            )}
+          </section>
+        </div>
+      </div>
+      <div className={styles.wrapper}>
+        <div className={styles.carouselComp}>
+          <title className={styles.CategoryTitle}>평균별점이 높은 작품</title>
+          <section
+            className={styles.bottomSlider}
+            onScroll={cursorBottom}
+            ref={sectionBottom}
+          >
+            {moviePosters.movies.map(movies => (
+              <Carousel6Card key={movies.id} movies={movies} />
+            ))}
+          </section>
+        </div>
+        {scrollXBottom === 0 ? null : (
+          <FontAwesomeIcon
+            icon={faCircleChevronLeft}
+            className={styles.bottomLeft}
+            onClick={() => {
+              moveLeftBottom(-1434);
+            }}
+          />
+        )}
+        {scrollXBottom > 1400 ? null : (
+          <FontAwesomeIcon
+            icon={faCircleChevronRight}
+            className={styles.bottomRight}
+            onClick={() => {
+              moveLeftBottom(1434);
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Carousel6;

--- a/src/components/Carousel6/Carousel6.module.scss
+++ b/src/components/Carousel6/Carousel6.module.scss
@@ -1,0 +1,152 @@
+.carouselComp {
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  margin: 0 1vw;
+}
+
+.CategoryTitle {
+  display: flex;
+  font-size: 30px;
+  width: 100%;
+  margin: 2vw 2vw 1vw 0;
+}
+
+.topSlider {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+  scrollbar-width: none; /* for Firefox */
+}
+
+.topSlider::-webkit-scrollbar {
+  display: none; /* for Chrome, Safari, and Opera */
+}
+
+.bottomSlider {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  margin-bottom: 2vw;
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+  scrollbar-width: none; /* for Firefox */
+}
+
+.bottomSlider::-webkit-scrollbar {
+  display: none; /* for Chrome, Safari, and Opera */
+}
+
+.posterArea {
+  display: flex;
+  flex-direction: column;
+  width: 13.4rem;
+  margin-right: 1.7vw;
+}
+
+.posterImg {
+  aspect-ratio: 1/1.45;
+  object-fit: cover;
+  object-position: center;
+  width: 13.4rem;
+  border-radius: 3px;
+  border: 0.5px solid rgb(204, 204, 204);
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 13.4rem;
+  padding-top: 0.2vw;
+}
+
+.movieName {
+  display: inline-block;
+  font-size: 1rem;
+  font-weight: 600;
+  width: 100%;
+  padding: 0.7vw 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.ratings {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: rgb(98, 98, 98);
+}
+
+.icon {
+  display: flex;
+  font-size: 0.6rem;
+  color: rgb(98, 98, 98);
+}
+
+.topLeft {
+  float: left;
+  position: inherit;
+  top: 50%;
+  font-size: 1.6rem;
+  color: white;
+  background-color: rgb(195, 193, 193);
+  border-radius: 1rem;
+}
+
+.topLeft:hover {
+  background-color: black;
+  cursor: pointer;
+}
+
+.topRight {
+  float: right;
+  position: absolute;
+  top: 28vh;
+  right: 0vh;
+  font-size: 1.6rem;
+  color: white;
+  background-color: rgb(195, 193, 193);
+  border-radius: 1rem;
+}
+
+.topRight:hover {
+  background-color: black;
+  cursor: pointer;
+}
+
+.bottomLeft {
+  float: left;
+  position: absolute;
+  bottom: 14vh;
+  font-size: 1.6rem;
+  color: white;
+  background-color: rgb(195, 193, 193);
+  border-radius: 1rem;
+}
+
+.bottomLeft:hover {
+  background-color: black;
+  cursor: pointer;
+}
+
+.bottomRight {
+  float: right;
+  position: absolute;
+  bottom: 14vh;
+  right: 0vh;
+  font-size: 1.6rem;
+  color: white;
+  background-color: rgb(195, 193, 193);
+  border-radius: 1rem;
+}
+
+.bottomRight:hover {
+  background-color: black;
+  cursor: pointer;
+}

--- a/src/components/Carousel6/Carousel6Card.js
+++ b/src/components/Carousel6/Carousel6Card.js
@@ -1,0 +1,21 @@
+import styles from './Carousel6.module.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+
+function Carousel6Card({ movies }) {
+  return (
+    <section className={styles.posterArea}>
+      <img className={styles.posterImg} src={movies.imgUrl} />
+      <div className={styles.info}>
+        <p className={styles.movieName}>{movies.name}</p>
+        <p className={styles.ratings}>
+          평균
+          <FontAwesomeIcon icon={faStar} className={styles.icon} />
+          {movies.ratings}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default Carousel6Card;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
-  6개 이미지 carousel 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 크롬 기준 100% 화면 너비에 맞춰 사진 6개어치의 픽셀값으로 x축 이동하도록 슬라이더 구현

2. 목데이터 이용해서 구현, 추후에 데이터베이스랑 연결 필요

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- git을 다룰 땐 조심하자... useRef의 개념을 새로 이해하고 적용

<br />

## :: 기타 질문 및 특이 사항
- 화면 너비가 변하면 그에 따라 맞는 사진의 갯수만큼 넘어가게 할 수 있는 로직 필요 
