### PR TITLE
Fix: Carousel5컴포넌트 CSS 전체선택자 제거

### DIFF
--- a/src/components/Carousel5/Carousel5.module.scss
+++ b/src/components/Carousel5/Carousel5.module.scss
@@ -1,4 +1,5 @@
 .Carousel5Wrapper {
+  box-sizing: border-box;
   position: relative;
   margin-top: 60px;
   padding-left: 10px;
@@ -9,6 +10,7 @@
   }
 }
 .SliderWrapper {
+  box-sizing: border-box;
   white-space: nowrap;
   position: relative;
   width: 100%;
@@ -21,9 +23,11 @@
   }
 }
 .SliderWrapper::-webkit-scrollbar {
+  box-sizing: border-box;
   display: none;
 }
 .Title {
+  box-sizing: border-box;
   font-size: 23px;
   font-weight: bold;
   padding-bottom: 10px;
@@ -32,6 +36,7 @@
 }
 
 .DivForButton {
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   position: absolute;
@@ -46,6 +51,7 @@
 }
 
 .Button {
+  box-sizing: border-box;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/Carousel5/MovieCard/MovieCard.module.scss
+++ b/src/components/Carousel5/MovieCard/MovieCard.module.scss
@@ -1,7 +1,5 @@
-* {
-  box-sizing: border-box;
-}
 .MovieCardWrapper {
+  box-sizing: border-box;
   display: inline-block;
   padding: 8px;
   width: 20%;
@@ -14,6 +12,7 @@
 }
 
 .PosterBox {
+  box-sizing: border-box;
   position: relative;
   left: 0;
   top: 0;
@@ -23,10 +22,12 @@
   border: solid rgb(230, 230, 230) 1px;
 }
 .PosterImage {
+  box-sizing: border-box;
   display: block;
   width: 100%;
 }
 .MovieInfoWrapper {
+  box-sizing: border-box;
   width: 100%;
   padding-top: 5px;
   > div {
@@ -34,19 +35,23 @@
   }
 }
 .MovieInfoTitle {
+  box-sizing: border-box;
   font-size: 18px;
   font-weight: bold;
 }
 .MovieInfoSubWrapper {
+  box-sizing: border-box;
   font-size: 15px;
 }
 .MovieInfoRating {
+  box-sizing: border-box;
   font-size: 15px;
   padding-top: 3px;
   color: rgb(67, 68, 82);
 }
 
 .SequenceNumberBox {
+  box-sizing: border-box;
   position: absolute;
   border-radius: 5px;
   font-size: 18px;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- Carousel5컴포넌트의 CSS에서 전체 선택자(*)를 제거

<br />

## :: 구현 사항 설명
1. Carousel5컴포넌트의 CSS에서 전체 선택자(*)를 제거


<br />

## :: 성장 포인트
- 다른 컴포넌트에도 영향을 주는 전체 선택자를 사용하지 않도록 해야겠음.
<br />

## :: 기타 질문 및 특이 사항
- 없음
